### PR TITLE
Change honeycomb dataset to kubernetes-logs

### DIFF
--- a/logs/quickstart.yaml
+++ b/logs/quickstart.yaml
@@ -43,7 +43,7 @@ metadata:
 data:
   config.yaml: |-
     watchers:
-      - dataset: kubernetestest
+      - dataset: kubernetes-logs
         labelSelector: ""
         parser: glog
     verbosity: debug


### PR DESCRIPTION
The readme states that configuring this manifest will create a honeycomb dataset called "kubernetes-logs" but this is the old quickstart.yml that sets up a dataset called kubernetestest. I've changed it to match the readme.