### PR TITLE
Updates/fixes kubernetes agent quickstart

### DIFF
--- a/logs/quickstart.yaml
+++ b/logs/quickstart.yaml
@@ -26,7 +26,7 @@ metadata:
   namespace: kube-system
 rules:
   - apiGroups:
-    - "*"
+    - ""
     resources:
     - pods
     verbs:
@@ -42,11 +42,30 @@ metadata:
   namespace: kube-system
 data:
   config.yaml: |-
+    # By default, submit logs from interesting system pods such as the
+    # kube API server
     watchers:
       - dataset: kubernetes-logs
-        labelSelector: ""
+        labelSelector: "k8s-app=kube-apiserver"
+        namespace: kube-system
         parser: glog
-    verbosity: debug
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-scheduler"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-controller-manager"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=kube-proxy"
+        namespace: kube-system
+        parser: glog
+      - dataset: kubernetes-logs
+        labelSelector: "k8s-app=dns-controller"
+        namespace: kube-system
+        parser: glog
+    verbosity: info
 
 # Daemonset
 ---


### PR DESCRIPTION
- minor fix to the ClusterRole spec
- change the default watcher configuration. In practice, using an empty labelSelector results in the agent doing way more work than needed. I provided a few examples of system containers that work correctly with the glog parser. This also better demonstrates how to define multiple watchers.