### PR TITLE
Use default namespace, split out minikube manifest for logs agent

### DIFF
--- a/logs/quickstart-minikube.yaml
+++ b/logs/quickstart-minikube.yaml
@@ -123,6 +123,12 @@ spec:
         - mountPath: "/var/lib/docker/containers"
           name: varlibdockercontainers
           readOnly: true
+        # In minikube, /var/lib/docker is symlinked to # /mnt/sda1/var/lib/docker,
+        # so mount that path as well. This mount can be removed in a production
+        # deployment.
+        - mountPath: "/mnt/sda1/var/lib/docker/containers"
+          name: minikube-varlibdockercontainers
+          readOnly: true
       serviceAccountName: honeycomb-serviceaccount
       terminationGracePeriodSeconds: 30
       volumes:
@@ -138,3 +144,6 @@ spec:
       - hostPath:
           path: "/var/lib/docker/containers"
         name: varlibdockercontainers
+      - hostPath:
+          path: "/mnt/sda1/var/lib/docker/containers"
+        name: minikube-varlibdockercontainers


### PR DESCRIPTION
Running the logs agent DaemonSet in the `default` namespace should
hopefully address issues in GKE and AKS where DaemonSets in the
`kube-system` namespace get deleted. It may also make debugging a bit
easier because users don't have to remember to add
`--namespace kube-system` to kubectl commands.

Also add a separate `quickstart-minikube` manifest with the additional
minikube-specific volume mounts. Fixes
https://github.com/honeycombio/honeycomb-kubernetes-agent/issues/23

Note that we'll have to update the docs at
https://docs.honeycomb.io/thinking-about-observability/getting-started-with/kubernetes/
to match these changes.

Tested in minikube and dogfood cluster.