### PR TITLE
Update quickstarts to include new splitLogging option

### DIFF
--- a/logs/quickstart-aks.yaml
+++ b/logs/quickstart-aks.yaml
@@ -66,6 +66,9 @@ data:
         namespace: kube-system
         parser: nop
     verbosity: info
+    # splitLogging directs trace, debug, info, and warn log levels to stdout
+    # rather than stderr.
+    splitLogging: false
 
 # Daemonset
 ---

--- a/logs/quickstart-aws-eks.yaml
+++ b/logs/quickstart-aws-eks.yaml
@@ -58,6 +58,9 @@ data:
         namespace: kube-system
         parser: glog
     verbosity: info
+    # splitLogging directs trace, debug, info, and warn log levels to stdout
+    # rather than stderr.
+    splitLogging: false
 
 # Daemonset
 ---

--- a/logs/quickstart-gke.yaml
+++ b/logs/quickstart-gke.yaml
@@ -74,6 +74,9 @@ data:
         namespace: kube-system
         parser: nop
     verbosity: info
+    # splitLogging directs trace, debug, info, and warn log levels to stdout
+    # rather than stderr.
+    splitLogging: false
 
 # Daemonset
 ---

--- a/logs/quickstart-minikube.yaml
+++ b/logs/quickstart-minikube.yaml
@@ -66,6 +66,9 @@ data:
         namespace: kube-system
         parser: glog
     verbosity: info
+    # splitLogging directs trace, debug, info, and warn log levels to stdout
+    # rather than stderr.
+    splitLogging: false
 
 # Daemonset
 ---

--- a/logs/quickstart.yaml
+++ b/logs/quickstart.yaml
@@ -66,6 +66,9 @@ data:
         namespace: kube-system
         parser: glog
     verbosity: info
+    # splitLogging directs trace, debug, info, and warn log levels to stdout
+    # rather than stderr.
+    splitLogging: false
 
 # Daemonset
 ---


### PR DESCRIPTION
If https://github.com/honeycombio/honeycomb-kubernetes-agent/pull/27 lands, we'll need to update the quickstarts to include this new option.